### PR TITLE
Use OffscreenCanvas for ASCII worker

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -25,7 +25,7 @@ There are currently no automated tests. Add `vitest` and `playwright` when ready
 - Initialized Vite + React + Tailwind structure.
 - Added API route for Vimeo files.
 - Added deployment workflow skeleton.
-- TODO: Implement WebGL shader logic in `asciiWorker.ts`.
+- Implemented WebGL shader logic in `asciiWorker.ts`.
 
 ## Governing Principles
 

--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ The static files will be in the `dist/` directory.
 A GitHub Action in `.github/workflows/deploy.yml` builds the project and uploads the bundle to your Webflow CDN bucket via `wrangler r2`.
 
 ## Notes
-- This is a starter skeleton. The WebGL shader in `src/workers/asciiWorker.ts` still needs to be implemented.
+- The ASCII worker implements a simple shader pipeline for real-time rendering.
 - Update the Webflow embed script to point to your CDN.

--- a/src/shaders/ascii.frag
+++ b/src/shaders/ascii.frag
@@ -1,12 +1,12 @@
-uniform sampler2D u_frame;
-uniform sampler2D u_glyphs;
+uniform sampler2D uFrame;
+uniform sampler2D uGlyphs;
 varying vec2 v_uv;
 
 void main() {
-  vec3 color = texture2D(u_frame, v_uv).rgb;
+  vec3 color = texture2D(uFrame, v_uv).rgb;
   float lum = dot(color, vec3(0.2126, 0.7152, 0.0722));
   int index = int(floor(lum * 15.0 + 0.5));
   vec2 cell = vec2(mod(float(index), 4.0), floor(float(index) / 4.0)) / 4.0;
   vec2 glyphUV = fract(v_uv * 128.0) / 4.0 + cell;
-  gl_FragColor = texture2D(u_glyphs, glyphUV) * vec4(color, 1.0);
+  gl_FragColor = texture2D(uGlyphs, glyphUV) * vec4(color, 1.0);
 }

--- a/src/workers/asciiWorker.ts
+++ b/src/workers/asciiWorker.ts
@@ -1,6 +1,125 @@
+import asciiFrag from '../shaders/ascii.frag?raw'
+
+let gl: WebGL2RenderingContext | null = null
+let program: WebGLProgram | null = null
+let vao: WebGLVertexArrayObject | null = null
+let frameTex: WebGLTexture | null = null
+let glyphTex: WebGLTexture | null = null
+let uFrameLoc: WebGLUniformLocation | null = null
+let uGlyphsLoc: WebGLUniformLocation | null = null
+
 self.onmessage = ({ data }) => {
-  const { video, canvas } = data
-  const gl = canvas.getContext('webgl2')
-  if (!gl) return
-  // TODO: upload frame -> texture, run glyph-map shader, render quad
+  if (data.canvas) {
+    gl = (data.canvas as OffscreenCanvas).getContext('webgl2')
+    if (gl) init(gl)
+    return
+  }
+
+  if (gl && data.frame) {
+    render(gl, data.frame as ImageBitmap)
+  }
+}
+
+function init(gl: WebGL2RenderingContext) {
+  const vertSrc = `
+    attribute vec2 position;
+    varying vec2 v_uv;
+    void main() {
+      v_uv = position * 0.5 + 0.5;
+      gl_Position = vec4(position, 0.0, 1.0);
+    }
+  `
+
+  const vs = gl.createShader(gl.VERTEX_SHADER)!
+  gl.shaderSource(vs, vertSrc)
+  gl.compileShader(vs)
+
+  const fs = gl.createShader(gl.FRAGMENT_SHADER)!
+  gl.shaderSource(fs, asciiFrag)
+  gl.compileShader(fs)
+
+  program = gl.createProgram()!
+  gl.attachShader(program, vs)
+  gl.attachShader(program, fs)
+  gl.linkProgram(program)
+
+  vao = gl.createVertexArray()!
+  gl.bindVertexArray(vao)
+  const vbo = gl.createBuffer()!
+  gl.bindBuffer(gl.ARRAY_BUFFER, vbo)
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array([
+      -1, -1,
+      1, -1,
+      -1, 1,
+      -1, 1,
+      1, -1,
+      1, 1
+    ]),
+    gl.STATIC_DRAW
+  )
+  const loc = gl.getAttribLocation(program, 'position')
+  gl.enableVertexAttribArray(loc)
+  gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0)
+
+  frameTex = gl.createTexture()!
+  gl.bindTexture(gl.TEXTURE_2D, frameTex)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+
+  glyphTex = createGlyphTexture(gl)
+
+  uFrameLoc = gl.getUniformLocation(program, 'uFrame')
+  uGlyphsLoc = gl.getUniformLocation(program, 'uGlyphs')
+}
+
+function createGlyphTexture(gl: WebGL2RenderingContext) {
+  const chars = [' ', '.', ':', '-', '=', '+', '*', '#', '%', '@', 'A', 'B', 'C', 'D', 'E', 'F']
+  const size = 256
+  const cell = size / 4
+  const canvas = new OffscreenCanvas(size, size)
+  const ctx = canvas.getContext('2d')!
+  ctx.fillStyle = '#000'
+  ctx.fillRect(0, 0, size, size)
+  ctx.fillStyle = '#fff'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.font = `${cell * 0.8}px monospace`
+
+  for (let i = 0; i < chars.length; i++) {
+    const x = (i % 4) * cell + cell / 2
+    const y = Math.floor(i / 4) * cell + cell / 2
+    ctx.fillText(chars[i], x, y)
+  }
+
+  const tex = gl.createTexture()!
+  gl.bindTexture(gl.TEXTURE_2D, tex)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, canvas)
+
+  return tex
+}
+
+function render(gl: WebGL2RenderingContext, frame: ImageBitmap) {
+  gl.viewport(0, 0, (gl.canvas as OffscreenCanvas).width, (gl.canvas as OffscreenCanvas).height)
+  gl.useProgram(program)
+  gl.bindVertexArray(vao)
+
+  gl.activeTexture(gl.TEXTURE0)
+  gl.bindTexture(gl.TEXTURE_2D, frameTex)
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, frame)
+  gl.uniform1i(uFrameLoc, 0)
+
+  gl.activeTexture(gl.TEXTURE1)
+  gl.bindTexture(gl.TEXTURE_2D, glyphTex)
+  gl.uniform1i(uGlyphsLoc, 1)
+
+  gl.drawArrays(gl.TRIANGLES, 0, 6)
+  frame.close()
 }


### PR DESCRIPTION
## Summary
- refine progress log in `AGENT.md`
- describe worker feature in `README`
- send an OffscreenCanvas and frame bitmaps in `AsciiLayer`
- adapt `asciiWorker` to use the OffscreenCanvas and camelCase uniforms
- update shader uniform names

## Testing
- `pnpm run build` *(fails: vite not found)*
