### PR TITLE
Improve scaling and add Codespaces script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 VIMEO_TOKEN=your_token_here
-VIMEO_RIP_URL=https://vimeo.com/123456789
+VITE_VIMEO_RIP_URL=https://vimeo.com/123456789

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo contains a React/Vite project that plays a Vimeo video and renders it 
 - [pnpm](https://pnpm.io/) package manager
 
 ## Setup
-1. Copy `.env.example` to `.env` and fill in your `VIMEO_TOKEN` and `VIMEO_RIP_URL`.
+1. Copy `.env.example` to `.env` and fill in your `VIMEO_TOKEN` and `VITE_VIMEO_RIP_URL`.
 2. Install dependencies:
    ```bash
    pnpm install
@@ -17,6 +17,14 @@ This repo contains a React/Vite project that plays a Vimeo video and renders it 
    pnpm dev
    ```
    The app will be available at `http://localhost:5173`.
+
+## Codespaces
+For development inside GitHub Codespaces, run the helper script:
+
+```bash
+./scripts/start.sh
+```
+This installs dependencies and starts the dev server automatically.
 
 ## Building for Production
 ```bash

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+pnpm install
+pnpm dev

--- a/src/components/AsciiLayer.tsx
+++ b/src/components/AsciiLayer.tsx
@@ -5,7 +5,16 @@ export function AsciiLayer({ target }: { target: RefObject<HTMLVideoElement> }) 
 
   useEffect(() => {
     const canvas = canvasRef.current
-    if (!canvas) return
+    const video = target.current
+    if (!canvas || !video) return
+
+    const resize = () => {
+      canvas.width = video.clientWidth
+      canvas.height = video.clientHeight
+    }
+    resize()
+    const observer = new ResizeObserver(resize)
+    observer.observe(video)
 
     const offscreen = canvas.transferControlToOffscreen()
     const worker = new Worker(new URL('../workers/asciiWorker.ts', import.meta.url), { type: 'module' })
@@ -13,19 +22,17 @@ export function AsciiLayer({ target }: { target: RefObject<HTMLVideoElement> }) 
 
     let raf: number
     async function loop() {
-      const video = target.current
-      if (video) {
-        const frame = await createImageBitmap(video)
-        worker.postMessage({ frame }, [frame])
-      }
+      const frame = await createImageBitmap(video)
+      worker.postMessage({ frame }, [frame])
       raf = requestAnimationFrame(loop)
     }
     raf = requestAnimationFrame(loop)
     return () => {
       cancelAnimationFrame(raf)
       worker.terminate()
+      observer.disconnect()
     }
   }, [target])
 
-  return <canvas ref={canvasRef} className="absolute inset-0 pointer-events-none" />
+  return <canvas ref={canvasRef} className="absolute inset-0 h-full w-full pointer-events-none" />
 }

--- a/src/components/HeroMontage.tsx
+++ b/src/components/HeroMontage.tsx
@@ -9,7 +9,7 @@ export function HeroMontage() {
   const videoRef = useRef<HTMLVideoElement>(null)
 
   return (
-    <section className="relative h-screen w-full overflow-hidden">
+    <section className="fixed inset-0 overflow-hidden">
       <video
         ref={videoRef}
         src={data?.src}


### PR DESCRIPTION
## Summary
- ensure env var uses Vite prefix
- sync video and ASCII canvas sizes via ResizeObserver
- make hero section fixed for full‑bleed video
- document Codespaces workflow and add start script

## Testing
- `pnpm install` *(fails: EHOSTUNREACH)*
- `pnpm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a2824f560832e998aee0e666e4120