### PR TITLE
Fix SWR import and API handler

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -26,6 +26,7 @@ There are currently no automated tests. Add `vitest` and `playwright` when ready
 - Added API route for Vimeo files.
 - Added deployment workflow skeleton.
 - Implemented WebGL shader logic in `asciiWorker.ts`.
+- Installed SWR and added in-memory caching for Vimeo API.
 
 ## Governing Principles
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "swr": "^2.2.0"
   },
   "devDependencies": {
     "vite": "^4.0.0",

--- a/pages/api/vimeo-file.ts
+++ b/pages/api/vimeo-file.ts
@@ -4,25 +4,35 @@ export const runtime = 'edge'
 
 const VIMEO = process.env.VIMEO_TOKEN!
 const CACHE = 60 * 60 * 24
+const cache = new Map<string, any>()
 
 export default async function handler(req: NextRequest) {
   const id = req.nextUrl.searchParams.get('id')?.match(/\d+/)?.[0]
   if (!id) return new Response('Bad ID', { status: 400 })
 
   const cacheKey = `vimeo-${id}`
-  const cached = await env.KV.get(cacheKey, 'json')
+  const cached = cache.get(cacheKey)
   if (cached) return Response.json(cached, { headers: { 'x-cache': 'HIT' } })
 
-  const res = await fetch(`https://api.vimeo.com/videos/${id}`, {
-    headers: { Authorization: `bearer ${VIMEO}` }
-  })
-  const json = await res.json()
+  try {
+    const res = await fetch(`https://api.vimeo.com/videos/${id}`, {
+      headers: { Authorization: `bearer ${VIMEO}` }
+    })
+    if (!res.ok) {
+      return new Response('Upstream error', { status: res.status })
+    }
+    const json = await res.json()
 
-  const mp4 = json.files
-    .filter((f: any) => f.type === 'video/mp4')
-    .sort((a: any, b: any) => b.width - a.width)[0]
+    const mp4 = json.files
+      .filter((f: any) => f.type === 'video/mp4')
+      .sort((a: any, b: any) => b.width - a.width)[0]
 
-  const payload = { src: mp4.link, width: mp4.width, height: mp4.height }
-  await env.KV.put(cacheKey, JSON.stringify(payload), { expirationTtl: CACHE })
-  return Response.json(payload, { headers: { 'x-cache': 'MISS' } })
+    const payload = { src: mp4.link, width: mp4.width, height: mp4.height }
+    cache.set(cacheKey, payload)
+    setTimeout(() => cache.delete(cacheKey), CACHE * 1000)
+    return Response.json(payload, { headers: { 'x-cache': 'MISS' } })
+  } catch (err) {
+    console.error(err)
+    return new Response('Internal Error', { status: 500 })
+  }
 }

--- a/src/components/HeroMontage.tsx
+++ b/src/components/HeroMontage.tsx
@@ -2,11 +2,26 @@ import { useRef } from 'react'
 import useSWR from 'swr'
 import { AsciiLayer } from './AsciiLayer'
 
-const fetcher = (url: string) => fetch(url).then(r => r.json())
+type VideoData = { src: string; width: number; height: number }
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error('Failed to fetch')
+  return res.json()
+}
 
 export function HeroMontage() {
-  const { data } = useSWR('/api/vimeo-file?id=' + import.meta.env.VITE_VIMEO_RIP_URL, fetcher)
+  const { data, error } = useSWR<VideoData>(
+    '/api/vimeo-file?id=' + import.meta.env.VITE_VIMEO_RIP_URL,
+    fetcher
+  )
   const videoRef = useRef<HTMLVideoElement>(null)
+
+  if (error) {
+    return (
+      <div className="p-4 text-red-500">Failed to load video</div>
+    )
+  }
 
   return (
     <section className="fixed inset-0 overflow-hidden">


### PR DESCRIPTION
## Summary
- install swr dependency
- use TypeScript generics with error handling in `HeroMontage`
- rework Vimeo API route to use in-memory cache instead of undefined `env`
- document latest changes in progress log

## Testing
- `pnpm run build` *(fails: vite not found because dependencies aren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_683a40922834832eb141cb5bc34edc04