### PR TITLE
Fix wrangler syntax

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,4 +8,4 @@ jobs:
       - uses: pnpm/action-setup@v3
       - run: pnpm i && pnpm run build
       - name: Upload bundle to Webflow CDN bucket
-        run: npx wrangler r2 put ascii-bundle.js dist/assets/index-*.js
+        run: npx wrangler r2 object put ascii-bundle.js dist/assets/index-*.js

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pnpm run build
 The static files will be in the `dist/` directory.
 
 ## Deployment
-A GitHub Action in `.github/workflows/deploy.yml` builds the project and uploads the bundle to your Webflow CDN bucket via `wrangler r2`.
+A GitHub Action in `.github/workflows/deploy.yml` builds the project and uploads the bundle to your Webflow CDN bucket via `wrangler r2 object put`.
 
 ## Notes
 - The ASCII worker implements a simple shader pipeline for real-time rendering.


### PR DESCRIPTION
## Summary
- update the GitHub Actions workflow to use new `wrangler r2 object put` command
- update docs with the new command

## Testing
- `pnpm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a42c70f10832e98d1a21c76426e8a