### PR TITLE
Fix PNPM setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 8.9.0
+          run_install: false
       - run: pnpm i && pnpm run build
       - name: Upload bundle to Webflow CDN bucket
         run: npx wrangler r2 object put ascii-bundle.js dist/assets/index-*.js


### PR DESCRIPTION
## Summary
- pin pnpm version to 8.9.0 for the CI build

## Testing
- `node -v`
- `corepack prepare pnpm@8.9.0 --activate` *(fails: EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683a440a1d2c832ea2beb9ac44a69354