### PR TITLE
Fix canvas transfer error and remove wrangler step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: build-and-upload
+name: build
 on: [push]
 jobs:
   build:
@@ -10,5 +10,3 @@ jobs:
           version: 8.9.0
           run_install: false
       - run: pnpm i && pnpm run build
-      - name: Upload bundle to Webflow CDN bucket
-        run: npx wrangler r2 object put ascii-bundle.js dist/assets/index-*.js

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ pnpm run build
 The static files will be in the `dist/` directory.
 
 ## Deployment
-A GitHub Action in `.github/workflows/deploy.yml` builds the project and uploads the bundle to your Webflow CDN bucket via `wrangler r2 object put`.
+A GitHub Action in `.github/workflows/deploy.yml` builds the project when you push changes.
 
 ## Notes
 - The ASCII worker implements a simple shader pipeline for real-time rendering.
-- Update the Webflow embed script to point to your CDN.

--- a/src/components/AsciiLayer.tsx
+++ b/src/components/AsciiLayer.tsx
@@ -8,13 +8,8 @@ export function AsciiLayer({ target }: { target: RefObject<HTMLVideoElement> }) 
     const video = target.current
     if (!canvas || !video) return
 
-    const resize = () => {
-      canvas.width = video.clientWidth
-      canvas.height = video.clientHeight
-    }
-    resize()
-    const observer = new ResizeObserver(resize)
-    observer.observe(video)
+    canvas.width = video.clientWidth
+    canvas.height = video.clientHeight
 
     const offscreen = canvas.transferControlToOffscreen()
     const worker = new Worker(new URL('../workers/asciiWorker.ts', import.meta.url), { type: 'module' })
@@ -30,7 +25,6 @@ export function AsciiLayer({ target }: { target: RefObject<HTMLVideoElement> }) 
     return () => {
       cancelAnimationFrame(raf)
       worker.terminate()
-      observer.disconnect()
     }
   }, [target])
 


### PR DESCRIPTION
## Summary
- avoid resizing canvas after transferring control to OffscreenCanvas
- drop wrangler deployment step from CI
- update docs to match new CI pipeline

## Testing
- `pnpm -v` *(fails: no network access)*

------
https://chatgpt.com/codex/tasks/task_e_683a46d67ec0832e8017d5c1bc841d7f