### PR TITLE
Fix video frame capture start condition

### DIFF
--- a/src/components/AsciiLayer.tsx
+++ b/src/components/AsciiLayer.tsx
@@ -20,8 +20,10 @@ export function AsciiLayer({ target }: { target: RefObject<HTMLVideoElement> }) 
 
     let raf: number
     async function loop() {
-      const frame = await createImageBitmap(video)
-      worker.postMessage({ frame }, [frame])
+      if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+        const frame = await createImageBitmap(video)
+        worker.postMessage({ frame }, [frame])
+      }
       raf = requestAnimationFrame(loop)
     }
     raf = requestAnimationFrame(loop)


### PR DESCRIPTION
## Summary
- avoid InvalidStateError by checking `readyState` before capturing frames

## Testing
- `pnpm run build` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_683a4cfa79e8832e82392fc890e4577c