### PR TITLE
Add devcontainer config and update codespace setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "Personal Site",
+  "image": "mcr.microsoft.com/devcontainers/node:18",
+  "features": {
+    "ghcr.io/devcontainers/features/pnpm:1": {
+      "version": "8.9.0"
+    }
+  },
+  "postCreateCommand": "pnpm install"
+}

--- a/README.md
+++ b/README.md
@@ -3,28 +3,29 @@
 This repo contains a React/Vite project that plays a Vimeo video and renders it as real-time ASCII art. Follow these steps to run it locally.
 
 ## Prerequisites
-- [Node.js](https://nodejs.org/) 18+
-- [pnpm](https://pnpm.io/) package manager
+- [Node.js](https://nodejs.org/) 18+ (Corepack enabled)
+- [pnpm](https://pnpm.io/) 8.9.0
 
 ## Setup
 1. Copy `.env.example` to `.env` and fill in your `VIMEO_TOKEN` and `VITE_VIMEO_VIDEO_ID`.
 2. Install dependencies:
    ```bash
-   pnpm install
+   corepack pnpm install
    ```
 3. Start the dev server:
    ```bash
-   pnpm dev
+   corepack pnpm dev
    ```
    The app will be available at `http://localhost:5173`.
 
 ## Codespaces
-For development inside GitHub Codespaces, run the helper script:
+For development inside GitHub Codespaces, run the helper script. The repository
+includes a devcontainer configuration that installs Node.js 18 and pnpm for you:
 
 ```bash
 ./scripts/start.sh
 ```
-This installs dependencies and starts the dev server automatically.
+This script installs dependencies and starts the dev server automatically.
 
 ## Building for Production
 ```bash

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
-pnpm install
-pnpm dev
+set -e
+corepack pnpm install
+corepack pnpm dev


### PR DESCRIPTION
## Summary
- provide a `.devcontainer` configuration targeting Node 18 with pnpm 8.9
- update helper script to use `corepack pnpm`
- document the new setup in `README`

## Testing
- `pnpm run build` *(fails: EHOSTUNREACH while downloading pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_683b5d202b3c832e9c346a34f22dda24