### PR TITLE
Update devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,5 +6,6 @@
       "version": "8.9.0"
     }
   },
-  "postCreateCommand": "pnpm install"
+  "postCreateCommand": "corepack pnpm install",
+  "forwardPorts": [5173]
 }


### PR DESCRIPTION
## Summary
- ensure `corepack` installs dependencies automatically
- expose port 5173 for local development

## Testing
- `pnpm --version` *(fails: Connect Timeout Error)*

------
https://chatgpt.com/codex/tasks/task_e_683b6099c430832ea564d947d8dfaa0e