### PR TITLE
Add quick env setup snippet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,10 @@
+# Copy this file to ".env" and fill in your credentials.
+# Alternatively run:
+#
+#   cat > .env <<'EOF'
+#   VIMEO_TOKEN=<your-vimeo-token>
+#   VITE_VIMEO_VIDEO_ID=<your-video-id>
+#   EOF
+
 VIMEO_TOKEN=
 VITE_VIMEO_VIDEO_ID=

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ This repo contains a React/Vite project that plays a Vimeo video and renders it 
    VIMEO_TOKEN=<your-vimeo-token>
    VITE_VIMEO_VIDEO_ID=<your-video-id>
    ```
+
+   You can quickly generate this file with:
+
+   ```bash
+   cat > .env <<'EOF'
+   VIMEO_TOKEN=<your-vimeo-token>
+   VITE_VIMEO_VIDEO_ID=<your-video-id>
+   EOF
+   ```
 2. Install dependencies:
    ```bash
    corepack pnpm install


### PR DESCRIPTION
## Summary
- document a handy snippet to create `.env`
- include the snippet inside `.env.example`

## Testing
- `pnpm install` *(fails: connect EHOSTUNREACH)*
- `pnpm run build` *(fails: EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683b6a2972f8832eb11b0c923a0925c1