### PR TITLE
Fix Vimeo JSON fetch detection

### DIFF
--- a/src/components/HeroMontage.tsx
+++ b/src/components/HeroMontage.tsx
@@ -11,7 +11,8 @@ const fetcher = async (url: string) => {
     headers: { Authorization: `bearer ${VIMEO_TOKEN}` }
   })
   const type = res.headers.get('content-type') || ''
-  if (!res.ok || !type.includes('application/json')) {
+  const isJson = type.includes('application/json') || type.includes('+json')
+  if (!res.ok || !isJson) {
     const text = await res.text().catch(() => '')
     const message = !res.ok
       ? `HTTP ${res.status}: ${text}`


### PR DESCRIPTION
## Summary
- relax MIME type check to allow `+json` responses

## Testing
- `pnpm run build` *(fails: connect timeout to registry)*

------
https://chatgpt.com/codex/tasks/task_e_683b7898da34832eb74addbb4da7f346