### PR TITLE
Fix ASCII shader init and cleanup hero

### DIFF
--- a/src/components/HeroMontage.tsx
+++ b/src/components/HeroMontage.tsx
@@ -87,9 +87,6 @@ export function HeroMontage() {
         className="absolute inset-0 h-full w-full object-cover"
       />
       <AsciiLayer target={videoRef} />
-      <div className="relative z-10 p-6 text-white mix-blend-difference">
-        <h1 className="text-4xl font-bold">Danny Duran — Creative Director</h1>
-      </div>
     </section>
   )
 }

--- a/src/shaders/ascii.frag
+++ b/src/shaders/ascii.frag
@@ -1,3 +1,5 @@
+precision mediump float;
+
 uniform sampler2D uFrame;
 uniform sampler2D uGlyphs;
 varying vec2 v_uv;

--- a/src/workers/asciiWorker.ts
+++ b/src/workers/asciiWorker.ts
@@ -22,6 +22,7 @@ self.onmessage = ({ data }) => {
 
 function init(gl: WebGL2RenderingContext) {
   const vertSrc = `
+    precision mediump float;
     attribute vec2 position;
     varying vec2 v_uv;
     void main() {
@@ -33,15 +34,24 @@ function init(gl: WebGL2RenderingContext) {
   const vs = gl.createShader(gl.VERTEX_SHADER)!
   gl.shaderSource(vs, vertSrc)
   gl.compileShader(vs)
+  if (!gl.getShaderParameter(vs, gl.COMPILE_STATUS)) {
+    console.error('Vertex shader error:', gl.getShaderInfoLog(vs))
+  }
 
   const fs = gl.createShader(gl.FRAGMENT_SHADER)!
   gl.shaderSource(fs, asciiFrag)
   gl.compileShader(fs)
+  if (!gl.getShaderParameter(fs, gl.COMPILE_STATUS)) {
+    console.error('Fragment shader error:', gl.getShaderInfoLog(fs))
+  }
 
   program = gl.createProgram()!
   gl.attachShader(program, vs)
   gl.attachShader(program, fs)
   gl.linkProgram(program)
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    console.error('Program link error:', gl.getProgramInfoLog(program))
+  }
 
   vao = gl.createVertexArray()!
   gl.bindVertexArray(vao)


### PR DESCRIPTION
## Summary
- add precision qualifier to ASCII shader
- log shader compile and program link errors in worker
- remove header from hero component

## Testing
- `pnpm run build` *(fails: Connect Timeout Error)*

------
https://chatgpt.com/codex/tasks/task_e_683b7d7353b8832ea4ee4760c9faec8a