### PR TITLE
Implement luminance matte and trailing ASCII effect

### DIFF
--- a/src/shaders/ascii.frag
+++ b/src/shaders/ascii.frag
@@ -2,13 +2,24 @@ precision mediump float;
 
 uniform sampler2D uFrame;
 uniform sampler2D uGlyphs;
+uniform sampler2D uPrev;
+uniform float uFade;
+uniform float uThreshold;
 varying vec2 v_uv;
 
 void main() {
   vec3 color = texture2D(uFrame, v_uv).rgb;
   float lum = dot(color, vec3(0.2126, 0.7152, 0.0722));
+  vec4 prev = texture2D(uPrev, v_uv) * uFade;
+
+  if (lum < uThreshold) {
+    gl_FragColor = prev;
+    return;
+  }
+
   int index = int(floor(lum * 15.0 + 0.5));
   vec2 cell = vec2(mod(float(index), 4.0), floor(float(index) / 4.0)) / 4.0;
   vec2 glyphUV = fract(v_uv * 128.0) / 4.0 + cell;
-  gl_FragColor = texture2D(uGlyphs, glyphUV) * vec4(color, 1.0);
+  vec4 glyph = texture2D(uGlyphs, glyphUV);
+  gl_FragColor = vec4(vec3(1.0), glyph.a);
 }


### PR DESCRIPTION
## Summary
- add luminance threshold and fade uniforms in `ascii.frag`
- store previous frame texture and fade it each render in `asciiWorker`

## Testing
- `pnpm build` *(fails: unable to fetch pnpm packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_683baab43c24832eaa5f27dd73df1301