### PR TITLE
Tweak ASCII overlay orientation

### DIFF
--- a/src/shaders/ascii.frag
+++ b/src/shaders/ascii.frag
@@ -8,11 +8,11 @@ uniform float uThreshold;
 varying vec2 v_uv;
 
 void main() {
-  vec3 color = texture2D(uFrame, v_uv).rgb;
+  vec3 color = texture2D(uFrame, vec2(v_uv.x, 1.0 - v_uv.y)).rgb;
   float lum = dot(color, vec3(0.2126, 0.7152, 0.0722));
   vec4 prev = texture2D(uPrev, v_uv) * uFade;
 
-  if (lum < uThreshold) {
+  if (lum > uThreshold) {
     gl_FragColor = prev;
     return;
   }
@@ -21,5 +21,5 @@ void main() {
   vec2 cell = vec2(mod(float(index), 4.0), floor(float(index) / 4.0)) / 4.0;
   vec2 glyphUV = fract(v_uv * 128.0) / 4.0 + cell;
   vec4 glyph = texture2D(uGlyphs, glyphUV);
-  gl_FragColor = vec4(vec3(1.0), glyph.a);
+  gl_FragColor = vec4(vec3(0.2, 0.2, 0.21), glyph.a);
 }

--- a/src/workers/asciiWorker.ts
+++ b/src/workers/asciiWorker.ts
@@ -12,8 +12,8 @@ let uPrevLoc: WebGLUniformLocation | null = null
 let uFadeLoc: WebGLUniformLocation | null = null
 let uThresholdLoc: WebGLUniformLocation | null = null
 
-const THRESHOLD = 0.8
-const FADE = Math.exp(-1 / (0.5 * 60))
+const THRESHOLD = 0.33
+const FADE = Math.exp(-1 / (0.25 * 60))
 
 self.onmessage = ({ data }) => {
   if (data.canvas) {
@@ -120,8 +120,7 @@ function createGlyphTexture(gl: WebGL2RenderingContext) {
   const cell = size / 4
   const canvas = new OffscreenCanvas(size, size)
   const ctx = canvas.getContext('2d')!
-  ctx.fillStyle = '#000'
-  ctx.fillRect(0, 0, size, size)
+  ctx.clearRect(0, 0, size, size)
   ctx.fillStyle = '#fff'
   ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'


### PR DESCRIPTION
## Summary
- tweak luminance threshold and faster fade
- orient the frame texture correctly
- darken the glyph color
- create glyph texture with transparent background

## Testing
- `pnpm run build` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683badaea5dc832e91b14f3490429334