### PR TITLE
Adjust ASCII overlay sizing and behavior

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -29,6 +29,16 @@ There are currently no automated tests. Add `vitest` and `playwright` when ready
 - Installed SWR and added in-memory caching for Vimeo API.
 - Defined PNPM version for CI build.
 
+## API Usage
+Always fetch Vimeo data directly using:
+
+```
+https://api.vimeo.com/videos/<video-id>
+```
+
+Include an `Authorization: bearer <token>` header with the request.
+Do not use the `/api/vimeo-file` proxy route.
+
 ## Governing Principles
 
 THE WAY

--- a/src/components/AsciiLayer.tsx
+++ b/src/components/AsciiLayer.tsx
@@ -39,5 +39,10 @@ export function AsciiLayer({ target }: { target: RefObject<HTMLVideoElement> }) 
     }
   }, [target])
 
-  return <canvas ref={canvasRef} className="absolute inset-0 h-full w-full pointer-events-none" />
+  return (
+    <canvas
+      ref={canvasRef}
+      className="absolute inset-0 h-full w-full object-cover pointer-events-none"
+    />
+  )
 }

--- a/src/shaders/ascii.frag
+++ b/src/shaders/ascii.frag
@@ -2,24 +2,20 @@ precision mediump float;
 
 uniform sampler2D uFrame;
 uniform sampler2D uGlyphs;
-uniform sampler2D uPrev;
-uniform float uFade;
 uniform float uThreshold;
 varying vec2 v_uv;
 
 void main() {
   vec3 color = texture2D(uFrame, vec2(v_uv.x, 1.0 - v_uv.y)).rgb;
   float lum = dot(color, vec3(0.2126, 0.7152, 0.0722));
-  vec4 prev = texture2D(uPrev, v_uv) * uFade;
-
   if (lum > uThreshold) {
-    gl_FragColor = prev;
+    gl_FragColor = vec4(0.0);
     return;
   }
 
   int index = int(floor(lum * 15.0 + 0.5));
   vec2 cell = vec2(mod(float(index), 4.0), floor(float(index) / 4.0)) / 4.0;
-  vec2 glyphUV = fract(v_uv * 128.0) / 4.0 + cell;
+  vec2 glyphUV = fract(v_uv * 64.0) / 4.0 + cell;
   vec4 glyph = texture2D(uGlyphs, glyphUV);
   gl_FragColor = vec4(vec3(0.2, 0.2, 0.21), glyph.a);
 }

--- a/src/workers/asciiWorker.ts
+++ b/src/workers/asciiWorker.ts
@@ -7,13 +7,9 @@ let frameTex: WebGLTexture | null = null
 let glyphTex: WebGLTexture | null = null
 let uFrameLoc: WebGLUniformLocation | null = null
 let uGlyphsLoc: WebGLUniformLocation | null = null
-let prevTex: WebGLTexture | null = null
-let uPrevLoc: WebGLUniformLocation | null = null
-let uFadeLoc: WebGLUniformLocation | null = null
 let uThresholdLoc: WebGLUniformLocation | null = null
 
 const THRESHOLD = 0.33
-const FADE = Math.exp(-1 / (0.25 * 60))
 
 self.onmessage = ({ data }) => {
   if (data.canvas) {
@@ -89,28 +85,8 @@ function init(gl: WebGL2RenderingContext) {
 
   glyphTex = createGlyphTexture(gl)
 
-  prevTex = gl.createTexture()!
-  gl.bindTexture(gl.TEXTURE_2D, prevTex)
-  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
-  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
-  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
-  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
-  gl.texImage2D(
-    gl.TEXTURE_2D,
-    0,
-    gl.RGBA,
-    (gl.canvas as OffscreenCanvas).width,
-    (gl.canvas as OffscreenCanvas).height,
-    0,
-    gl.RGBA,
-    gl.UNSIGNED_BYTE,
-    null
-  )
-
   uFrameLoc = gl.getUniformLocation(program, 'uFrame')
   uGlyphsLoc = gl.getUniformLocation(program, 'uGlyphs')
-  uPrevLoc = gl.getUniformLocation(program, 'uPrev')
-  uFadeLoc = gl.getUniformLocation(program, 'uFade')
   uThresholdLoc = gl.getUniformLocation(program, 'uThreshold')
 }
 
@@ -157,23 +133,8 @@ function render(gl: WebGL2RenderingContext, frame: ImageBitmap) {
   gl.bindTexture(gl.TEXTURE_2D, glyphTex)
   gl.uniform1i(uGlyphsLoc, 1)
 
-  gl.activeTexture(gl.TEXTURE2)
-  gl.bindTexture(gl.TEXTURE_2D, prevTex)
-  gl.uniform1i(uPrevLoc, 2)
-  gl.uniform1f(uFadeLoc, FADE)
   gl.uniform1f(uThresholdLoc, THRESHOLD)
 
   gl.drawArrays(gl.TRIANGLES, 0, 6)
-  gl.bindTexture(gl.TEXTURE_2D, prevTex)
-  gl.copyTexImage2D(
-    gl.TEXTURE_2D,
-    0,
-    gl.RGBA,
-    0,
-    0,
-    (gl.canvas as OffscreenCanvas).width,
-    (gl.canvas as OffscreenCanvas).height,
-    0
-  )
   frame.close()
 }


### PR DESCRIPTION
## Summary
- remove previous frame fade logic from ASCII shader and worker
- double ASCII character size for a chunkier effect
- apply `object-cover` on the canvas so it crops identically to the video
- document direct Vimeo API usage in `AGENT.md`

## Testing
- `pnpm install` *(fails: unable to fetch packages)*
- `pnpm run build` *(fails: unable to fetch packages)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683baff8b304832ea7f3f22e242fecac