### PR TITLE
Update Vimeo API usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,9 @@
 # Alternatively run:
 #
 #   cat > .env <<'EOF'
-#   VIMEO_TOKEN=<your-vimeo-token>
+#   VITE_VIMEO_TOKEN=<your-vimeo-token>
 #   VITE_VIMEO_VIDEO_ID=<your-video-id>
 #   EOF
 
-VIMEO_TOKEN=
 VITE_VIMEO_TOKEN=
 VITE_VIMEO_VIDEO_ID=
-VITE_API_BASE=

--- a/README.md
+++ b/README.md
@@ -10,20 +10,16 @@ This repo contains a React/Vite project that plays a Vimeo video and renders it 
 1. Create a `.env` file in the project root with the following variables:
 
    ```bash
-   VIMEO_TOKEN=<your-vimeo-token>
    VITE_VIMEO_TOKEN=<your-vimeo-token>
    VITE_VIMEO_VIDEO_ID=<your-video-id>
-   VITE_API_BASE=<optional-api-base-url>
    ```
 
    You can quickly generate this file with:
 
    ```bash
    cat > .env <<'EOF'
-   VIMEO_TOKEN=<your-vimeo-token>
    VITE_VIMEO_TOKEN=<your-vimeo-token>
    VITE_VIMEO_VIDEO_ID=<your-video-id>
-   VITE_API_BASE=<optional-api-base-url>
    EOF
    ```
 2. Install dependencies:


### PR DESCRIPTION
## Summary
- fetch Vimeo videos directly from the Vimeo API
- update environment variable docs
- simplify `.env.example`

## Testing
- `corepack pnpm install` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_683bb945d538832ea393612744271229