### PR TITLE
Implement blend mode for ASCII overlay

### DIFF
--- a/src/components/AsciiLayer.tsx
+++ b/src/components/AsciiLayer.tsx
@@ -42,7 +42,7 @@ export function AsciiLayer({ target }: { target: RefObject<HTMLVideoElement> }) 
   return (
     <canvas
       ref={canvasRef}
-      className="absolute inset-0 h-full w-full object-cover pointer-events-none"
+      className="absolute inset-0 h-full w-full object-cover pointer-events-none mix-blend-screen"
     />
   )
 }

--- a/src/shaders/ascii.frag
+++ b/src/shaders/ascii.frag
@@ -17,5 +17,5 @@ void main() {
   vec2 cell = vec2(mod(float(index), 4.0), floor(float(index) / 4.0)) / 4.0;
   vec2 glyphUV = fract(v_uv * 64.0) / 4.0 + cell;
   vec4 glyph = texture2D(uGlyphs, glyphUV);
-  gl_FragColor = vec4(vec3(0.2, 0.2, 0.21), glyph.a);
+  gl_FragColor = vec4(vec3(1.0), glyph.a);
 }


### PR DESCRIPTION
## Summary
- make ASCII overlay white and use screen blend

## Testing
- `pnpm install` *(fails: Connect Timeout Error)*

------
https://chatgpt.com/codex/tasks/task_e_683bbbd269d0832e90728f04215918bd