### PR TITLE
Fix ASCII-only rendering

### DIFF
--- a/src/components/AsciiLayer.tsx
+++ b/src/components/AsciiLayer.tsx
@@ -42,7 +42,7 @@ export function AsciiLayer({ target }: { target: RefObject<HTMLVideoElement> }) 
   return (
     <canvas
       ref={canvasRef}
-      className="absolute inset-0 h-full w-full object-cover pointer-events-none mix-blend-screen"
+      className="absolute inset-0 h-full w-full object-cover pointer-events-none"
     />
   )
 }

--- a/src/components/HeroMontage.tsx
+++ b/src/components/HeroMontage.tsx
@@ -83,7 +83,7 @@ export function HeroMontage() {
         loop
         playsInline
         crossOrigin="anonymous"
-        className="absolute inset-0 h-full w-full object-cover"
+        className="absolute inset-0 h-full w-full object-cover opacity-0"
       />
       <AsciiLayer target={videoRef} />
     </section>

--- a/src/shaders/ascii.frag
+++ b/src/shaders/ascii.frag
@@ -2,17 +2,12 @@ precision mediump float;
 
 uniform sampler2D uFrame;
 uniform sampler2D uGlyphs;
-uniform float uThreshold;
 uniform vec2 uCellCount;
 varying vec2 v_uv;
 
 void main() {
   vec3 color = texture2D(uFrame, vec2(v_uv.x, 1.0 - v_uv.y)).rgb;
   float lum = dot(color, vec3(0.2126, 0.7152, 0.0722));
-  if (lum > uThreshold) {
-    gl_FragColor = vec4(0.0);
-    return;
-  }
 
   int index = int(floor(lum * 15.0 + 0.5));
   vec2 cell = vec2(mod(float(index), 4.0), floor(float(index) / 4.0)) / 4.0;

--- a/src/workers/asciiWorker.ts
+++ b/src/workers/asciiWorker.ts
@@ -9,10 +9,8 @@ let frameTex: WebGLTexture | null = null
 let glyphTex: WebGLTexture | null = null
 let uFrameLoc: WebGLUniformLocation | null = null
 let uGlyphsLoc: WebGLUniformLocation | null = null
-let uThresholdLoc: WebGLUniformLocation | null = null
 let uCellCountLoc: WebGLUniformLocation | null = null
 
-const THRESHOLD = 0.33
 const CELL_W = 6
 const CELL_H = 8
 
@@ -95,7 +93,6 @@ function init(gl: WebGL2RenderingContext) {
 
   uFrameLoc = gl.getUniformLocation(program, 'uFrame')
   uGlyphsLoc = gl.getUniformLocation(program, 'uGlyphs')
-  uThresholdLoc = gl.getUniformLocation(program, 'uThreshold')
   uCellCountLoc = gl.getUniformLocation(program, 'uCellCount')
   const cellX = gl.canvas.width / CELL_W
   const cellY = gl.canvas.height / CELL_H
@@ -164,8 +161,6 @@ function render(gl: WebGL2RenderingContext, frame: ImageBitmap) {
   gl.activeTexture(gl.TEXTURE1)
   gl.bindTexture(gl.TEXTURE_2D, glyphTex)
   gl.uniform1i(uGlyphsLoc, 1)
-
-  gl.uniform1f(uThresholdLoc, THRESHOLD)
 
   gl.drawArrays(gl.TRIANGLES, 0, 6)
   gl.flush()


### PR DESCRIPTION
## Summary
- hide video element so only ASCII art is visible
- remove mix-blend style from ASCII canvas
- drop threshold logic so shader always draws ASCII

## Testing
- `corepack pnpm run build` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683bc0f96df8832e9ed8db30d272053c