### PR TITLE
Fix worker init when video ref not ready

### DIFF
--- a/src/components/AsciiLayer.tsx
+++ b/src/components/AsciiLayer.tsx
@@ -1,12 +1,18 @@
 import { RefObject, useEffect, useRef } from 'react'
 
-export function AsciiLayer({ target }: { target: RefObject<HTMLVideoElement> }) {
+export function AsciiLayer({
+  target,
+  ready
+}: {
+  target: RefObject<HTMLVideoElement>
+  ready: boolean
+}) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
     const canvas = canvasRef.current
     const video = target.current
-    if (!canvas || !video) return
+    if (!canvas || !video || !ready) return
 
     canvas.width = video.clientWidth
     canvas.height = video.clientHeight
@@ -37,7 +43,7 @@ export function AsciiLayer({ target }: { target: RefObject<HTMLVideoElement> }) 
         canvasRef.current = clone
       }
     }
-  }, [target])
+  }, [target, ready])
 
   return (
     <canvas

--- a/src/components/HeroMontage.tsx
+++ b/src/components/HeroMontage.tsx
@@ -85,7 +85,7 @@ export function HeroMontage() {
         crossOrigin="anonymous"
         className="absolute inset-0 h-full w-full object-cover opacity-0"
       />
-      <AsciiLayer target={videoRef} />
+      <AsciiLayer target={videoRef} ready={!!data} />
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- fix `AsciiLayer` initialization by waiting for the video element
- signal readiness from `HeroMontage`

## Testing
- `pnpm -v` *(fails: ConnectTimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_683bc2bc4148832ea4ac24e7c8b4a3e3