### PR TITLE
Improve setup instructions and env checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This repo contains a React/Vite project that plays a Vimeo video and renders it 
    VITE_VIMEO_VIDEO_ID=<your-video-id>
    EOF
    ```
+
+   A blank screen usually means these variables weren't configured correctly.
 2. Install dependencies:
    ```bash
    corepack pnpm install

--- a/src/components/AsciiLayer.tsx
+++ b/src/components/AsciiLayer.tsx
@@ -1,12 +1,18 @@
 import { RefObject, useEffect, useRef } from 'react'
 
-export function AsciiLayer({ target }: { target: RefObject<HTMLVideoElement> }) {
+export function AsciiLayer({
+  target,
+  ready
+}: {
+  target: RefObject<HTMLVideoElement>
+  ready: boolean
+}) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
     const canvas = canvasRef.current
     const video = target.current
-    if (!canvas || !video) return
+    if (!canvas || !video || !ready) return
 
     canvas.width = video.clientWidth
     canvas.height = video.clientHeight
@@ -37,7 +43,7 @@ export function AsciiLayer({ target }: { target: RefObject<HTMLVideoElement> }) 
         canvasRef.current = clone
       }
     }
-  }, [target])
+  }, [target, ready])
 
   return (
     <canvas

--- a/src/components/HeroMontage.tsx
+++ b/src/components/HeroMontage.tsx
@@ -34,6 +34,14 @@ const fetcher = async (url: string) => {
 const VIMEO_ID = import.meta.env.VITE_VIMEO_VIDEO_ID
 
 export function HeroMontage() {
+  if (!TOKEN || !VIMEO_ID) {
+    return (
+      <div className="p-4 text-red-500">
+        Missing VITE_VIMEO_TOKEN or VITE_VIMEO_VIDEO_ID. See README for setup.
+      </div>
+    )
+  }
+
   const { data, error } = useSWR<VideoData>(
     `https://api.vimeo.com/videos/${VIMEO_ID}`,
     fetcher,
@@ -85,7 +93,7 @@ export function HeroMontage() {
         crossOrigin="anonymous"
         className="absolute inset-0 h-full w-full object-cover opacity-0"
       />
-      <AsciiLayer target={videoRef} />
+      <AsciiLayer target={videoRef} ready={!!data} />
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- render an error when required Vimeo env variables are missing
- mention blank screen symptom in README

## Testing
- `pnpm -v` *(fails: attempted download from registry)*

------
https://chatgpt.com/codex/tasks/task_e_683bc2bc4148832ea4ac24e7c8b4a3e3