### PR TITLE
Fix Vimeo fetch query and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ This repo contains a React/Vite project that plays a Vimeo video and renders it 
    EOF
    ```
 
-   A blank screen usually means these variables weren't configured correctly.
+   A blank screen usually means the environment variables weren't configured
+   correctly or the Vimeo request was blocked. Double-check your token and video
+   ID.
 2. Install dependencies:
    ```bash
    corepack pnpm install

--- a/pages/api/vimeo-file.ts
+++ b/pages/api/vimeo-file.ts
@@ -24,7 +24,9 @@ export default async function handler(req: NextRequest) {
   if (cached) return Response.json(cached, { headers: { 'x-cache': 'HIT' } })
 
   try {
-    const res = await fetch(`https://api.vimeo.com/videos/${id}`, {
+    const url = `https://api.vimeo.com/videos/${id}?fields=files`
+    console.log('Fetching', url)
+    const res = await fetch(url, {
       headers: { Authorization: `bearer ${VIMEO}` }
     })
     if (!res.ok) {

--- a/src/components/HeroMontage.tsx
+++ b/src/components/HeroMontage.tsx
@@ -43,7 +43,7 @@ export function HeroMontage() {
   }
 
   const { data, error } = useSWR<VideoData>(
-    `https://api.vimeo.com/videos/${VIMEO_ID}`,
+    `https://api.vimeo.com/videos/${VIMEO_ID}?fields=files`,
     fetcher,
     {
       onError: err => console.error('Vimeo fetch error:', err),


### PR DESCRIPTION
## Summary
- clarify README about env vars and blocked requests
- specify `?fields=files` when fetching from Vimeo
- log URL when using edge API route

## Testing
- `pnpm run build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_683bcc333f8c832e9e2c7c867b14e974