### PR TITLE
Improve error handling for ASCII and Vimeo

### DIFF
--- a/src/components/AsciiLayer.tsx
+++ b/src/components/AsciiLayer.tsx
@@ -2,10 +2,12 @@ import { RefObject, useEffect, useRef } from 'react'
 
 export function AsciiLayer({
   target,
-  ready
+  ready,
+  onError
 }: {
   target: RefObject<HTMLVideoElement>
   ready: boolean
+  onError?: (msg: string | null) => void
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
@@ -13,6 +15,12 @@ export function AsciiLayer({
     const canvas = canvasRef.current
     const video = target.current
     if (!canvas || !video || !ready) return
+
+    if (!('transferControlToOffscreen' in canvas) ||
+        typeof OffscreenCanvas === 'undefined') {
+      onError?.('OffscreenCanvas not supported')
+      return
+    }
 
     canvas.width = video.clientWidth
     canvas.height = video.clientHeight
@@ -22,7 +30,14 @@ export function AsciiLayer({
       new URL('../workers/asciiWorker.ts', import.meta.url),
       { type: 'module' }
     )
+    const handleWorker = (e: MessageEvent) => {
+      if (e.data?.error && typeof e.data.error === 'string') {
+        onError?.(e.data.error)
+      }
+    }
+    worker.addEventListener('message', handleWorker)
     worker.postMessage({ canvas: offscreen }, [offscreen])
+    onError?.(null)
 
     let raf: number
     async function loop() {
@@ -35,6 +50,7 @@ export function AsciiLayer({
     raf = requestAnimationFrame(loop)
     return () => {
       cancelAnimationFrame(raf)
+      worker.removeEventListener('message', handleWorker)
       worker.terminate()
       if (canvas.parentNode) {
         const clone = canvas.cloneNode(false) as HTMLCanvasElement

--- a/src/components/HeroMontage.tsx
+++ b/src/components/HeroMontage.tsx
@@ -53,6 +53,8 @@ export function HeroMontage() {
   )
   const videoRef = useRef<HTMLVideoElement>(null)
   const [videoError, setVideoError] = useState<string | null>(null)
+  const [asciiError, setAsciiError] = useState<string | null>(null)
+  const [status, setStatus] = useState('Fetching Vimeo video...')
 
   useEffect(() => {
     const video = videoRef.current
@@ -73,10 +75,17 @@ export function HeroMontage() {
     }
   }, [data])
 
-  if (error || videoError) {
+  useEffect(() => {
+    if (data) {
+      console.log('Fetched Vimeo video data', data)
+      setStatus('Vimeo video loaded')
+    }
+  }, [data])
+
+  if (error || videoError || asciiError) {
     return (
       <div className="p-4 text-red-500">
-        {error ? error.message : videoError}
+        {error ? error.message : videoError || asciiError}
       </div>
     )
   }
@@ -93,7 +102,10 @@ export function HeroMontage() {
         crossOrigin="anonymous"
         className="absolute inset-0 h-full w-full object-cover opacity-0"
       />
-      <AsciiLayer target={videoRef} ready={!!data} />
+      <AsciiLayer target={videoRef} ready={!!data} onError={setAsciiError} />
+      <div className="pointer-events-none absolute top-2 left-2 rounded bg-black/50 px-2 py-1 text-xs text-white">
+        {status}
+      </div>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- report initialization failures from `asciiWorker`
- surface ASCII worker errors in `AsciiLayer`
- show Vimeo fetch status and ASCII errors in `HeroMontage`

## Testing
- `pnpm run build` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683be228d208832ebd51844b77aa2546