### PR TITLE
Update fonts and cleanup logs

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Personal Site</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Micro+5&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="./src/style.css" />
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { HeroMontage } from './components/HeroMontage'
 
 export default function App() {
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="min-h-screen bg-black text-white micro-5-regular">
       <HeroMontage />
     </div>
   )

--- a/src/components/AsciiLayer.tsx
+++ b/src/components/AsciiLayer.tsx
@@ -7,7 +7,7 @@ function startAscii(canvas: HTMLCanvasElement, video: HTMLVideoElement) {
   const chars = ' .:-=+*#%@'
   const cellW = 6
   const cellH = 8
-  ctx.font = '600 10px/8px "SF Mono", "IBM Plex Mono", monospace'
+  ctx.font = '400 10px/8px "Micro 5", sans-serif'
   ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'
   let raf: number

--- a/src/components/HeroMontage.tsx
+++ b/src/components/HeroMontage.tsx
@@ -64,7 +64,6 @@ export function HeroMontage() {
       setVideoError('Failed to play video')
     }
     const handleLoaded = () => {
-      console.log('Video loaded')
       setVideoError(null)
     }
     video.addEventListener('error', handleError)

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.micro-5-regular {
+  font-family: 'Micro 5', sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,7 +1,11 @@
 module.exports = {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
-    extend: {}
+    extend: {
+      fontFamily: {
+        micro5: ['"Micro 5"', 'sans-serif']
+      }
+    }
   },
   plugins: []
 }


### PR DESCRIPTION
## Summary
- load Google Micro 5 font in HTML
- style text with Micro 5
- use Micro 5 font for ASCII canvas
- remove `Video loaded` console log

## Testing
- `pnpm run build` *(fails: ConnectTimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_683e661bed64832e9bd74b146c5208a8