### PR TITLE
Add neon alphabet overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
 import { HeroMontage } from './components/HeroMontage'
+import { AlphabetSpectrum } from './components/AlphabetSpectrum'
 
 export default function App() {
   return (
-    <div className="min-h-screen bg-black text-white micro-5-regular">
+    <div className="relative min-h-screen bg-black text-white micro-5-regular">
       <HeroMontage />
+      <AlphabetSpectrum />
     </div>
   )
 }

--- a/src/components/AlphabetSpectrum.tsx
+++ b/src/components/AlphabetSpectrum.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export function AlphabetSpectrum() {
+  const chars = 'ABCDEFGHIJK+MNOPQRSTUVWXYZ'.split('')
+  const classes = [
+    'hsl0','hsl15','hsl30','hsl45','hsl60','hsl75','hsl90','hsl105','hsl120','hsl135','hsl150',
+    'hsl165','hsl180','hsl195','hsl210','hsl225','hsl240','hsl255','hsl270','hsl285','hsl300','hsl315','hsl330','hsl345','hsl360'
+  ]
+  return (
+    <div className="pointer-events-none absolute bottom-4 w-full text-center text-4xl">
+      {chars.map((char, idx) => (
+        <span key={idx} className={`${classes[idx]} px-0.5`}>
+          {char}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/src/style.css
+++ b/src/style.css
@@ -7,3 +7,31 @@
   font-weight: 400;
   font-style: normal;
 }
+
+@layer utilities {
+  .hsl0  { color: hsl(0 90% 50%); }
+  .hsl15 { color: hsl(15 90% 50%); }
+  .hsl30 { color: hsl(30 90% 50%); }
+  .hsl45 { color: hsl(45 90% 50%); }
+  .hsl60 { color: hsl(60 90% 50%); }
+  .hsl75 { color: hsl(75 90% 50%); }
+  .hsl90 { color: hsl(90 90% 50%); }
+  .hsl105{ color: hsl(105 90% 50%); }
+  .hsl120{ color: hsl(120 90% 50%); }
+  .hsl135{ color: hsl(135 90% 50%); }
+  .hsl150{ color: hsl(150 90% 50%); }
+  .hsl165{ color: hsl(165 90% 55%); }
+  .hsl180{ color: hsl(180 90% 50%); }
+  .hsl195{ color: hsl(195 90% 50%); }
+  .hsl210{ color: hsl(210 90% 50%); }
+  .hsl225{ color: hsl(225 90% 50%); }
+  .hsl240{ color: hsl(240 90% 50%); }
+  .hsl255{ color: hsl(255 90% 50%); }
+  .hsl270{ color: hsl(270 90% 50%); }
+  .hsl285{ color: hsl(285 90% 50%); }
+  .hsl300{ color: hsl(300 90% 50%); }
+  .hsl315{ color: hsl(315 90% 50%); }
+  .hsl330{ color: hsl(330 90% 50%); }
+  .hsl345{ color: hsl(345 90% 50%); }
+  .hsl360{ color: hsl(360 90% 50%); }
+}


### PR DESCRIPTION
## Summary
- create `AlphabetSpectrum` component for colored A-Z mapping
- add HSL color utility classes
- show the overlay in `App`

## Testing
- `pnpm run build` *(fails: unable to download pnpm due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683e6a18e8ac832e8a7786c2ef032dc9