### PR TITLE
Hue-driven ASCII mapping

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
 import { HeroMontage } from './components/HeroMontage'
+import { AlphabetSpectrum } from './components/AlphabetSpectrum'
 
 export default function App() {
   return (
-    <div className="min-h-screen bg-black text-white micro-5-regular">
+    <div className="relative min-h-screen bg-black text-white micro-5-regular">
       <HeroMontage />
+      <AlphabetSpectrum />
     </div>
   )
 }

--- a/src/components/AlphabetSpectrum.tsx
+++ b/src/components/AlphabetSpectrum.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export function AlphabetSpectrum() {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
+  const classes = [
+    'hsl0','hsl14','hsl28','hsl42','hsl56','hsl70','hsl84','hsl98','hsl112','hsl126','hsl140',
+    'hsl154','hsl168','hsl182','hsl196','hsl210','hsl224','hsl238','hsl252','hsl266','hsl280','hsl294','hsl308','hsl322','hsl336','hsl350'
+  ]
+  return (
+    <div className="pointer-events-none absolute bottom-4 w-full text-center text-4xl">
+      {chars.map((char, idx) => (
+        <span key={idx} className={`${classes[idx]} px-0.5`}>
+          {char}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/src/components/AsciiLayer.tsx
+++ b/src/components/AsciiLayer.tsx
@@ -1,10 +1,27 @@
 import { RefObject, useEffect, useRef } from 'react'
 
+function rgbToHue(r: number, g: number, b: number) {
+  const rr = r / 255
+  const gg = g / 255
+  const bb = b / 255
+  const max = Math.max(rr, gg, bb)
+  const min = Math.min(rr, gg, bb)
+  if (max === min) return 0
+  let h = 0
+  if (max === rr) h = (gg - bb) / (max - min)
+  else if (max === gg) h = 2 + (bb - rr) / (max - min)
+  else h = 4 + (rr - gg) / (max - min)
+  h *= 60
+  if (h < 0) h += 360
+  return h
+}
+
 function startAscii(canvas: HTMLCanvasElement, video: HTMLVideoElement) {
   canvas.width = video.videoWidth || video.clientWidth
   canvas.height = video.videoHeight || video.clientHeight
   const ctx = canvas.getContext('2d')!
-  const chars = ' .:-=+*#%@'
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+  const charCount = alphabet.length
   const cellW = 6
   const cellH = 8
   ctx.font = '400 10px/8px "Micro 5", sans-serif'
@@ -26,9 +43,15 @@ function startAscii(canvas: HTMLCanvasElement, video: HTMLVideoElement) {
         const g = data[i + 1]
         const b = data[i + 2]
         const lum = r * 0.2126 + g * 0.7152 + b * 0.0722
-        const idx = Math.floor((lum / 255) * (chars.length - 1))
-        ctx.fillStyle = `rgb(${r},${g},${b})`
-        ctx.fillText(chars[idx], x * cellW + cellW / 2, y * cellH + cellH / 2)
+        const hue = rgbToHue(r, g, b)
+        if (lum > 0.95 * 255) {
+          ctx.fillStyle = `hsl(${hue} 90% 55%)`
+          ctx.fillText('+', x * cellW + cellW / 2, y * cellH + cellH / 2)
+        } else {
+          const idx = Math.floor((hue / 360) * charCount)
+          ctx.fillStyle = `hsl(${hue} 90% 50%)`
+          ctx.fillText(alphabet[idx], x * cellW + cellW / 2, y * cellH + cellH / 2)
+        }
         i += 4
       }
     }

--- a/src/style.css
+++ b/src/style.css
@@ -7,3 +7,32 @@
   font-weight: 400;
   font-style: normal;
 }
+
+@layer utilities {
+  .hsl0   { color: hsl(0 90% 50%); }
+  .hsl14  { color: hsl(14 90% 50%); }
+  .hsl28  { color: hsl(28 90% 50%); }
+  .hsl42  { color: hsl(42 90% 50%); }
+  .hsl56  { color: hsl(56 90% 50%); }
+  .hsl70  { color: hsl(70 90% 50%); }
+  .hsl84  { color: hsl(84 90% 50%); }
+  .hsl98  { color: hsl(98 90% 50%); }
+  .hsl112 { color: hsl(112 90% 50%); }
+  .hsl126 { color: hsl(126 90% 50%); }
+  .hsl140 { color: hsl(140 90% 50%); }
+  .hsl154 { color: hsl(154 90% 50%); }
+  .hsl168 { color: hsl(168 90% 50%); }
+  .hsl182 { color: hsl(182 90% 50%); }
+  .hsl196 { color: hsl(196 90% 50%); }
+  .hsl210 { color: hsl(210 90% 50%); }
+  .hsl224 { color: hsl(224 90% 50%); }
+  .hsl238 { color: hsl(238 90% 50%); }
+  .hsl252 { color: hsl(252 90% 50%); }
+  .hsl266 { color: hsl(266 90% 50%); }
+  .hsl280 { color: hsl(280 90% 50%); }
+  .hsl294 { color: hsl(294 90% 50%); }
+  .hsl308 { color: hsl(308 90% 50%); }
+  .hsl322 { color: hsl(322 90% 50%); }
+  .hsl336 { color: hsl(336 90% 50%); }
+  .hsl350 { color: hsl(350 90% 50%); }
+}


### PR DESCRIPTION
## Summary
- map letters A-Z across hue in the ASCII renderer
- show `+` glyph for top 5% luminance
- update overlay to match the new hue distribution
- tweak HSL utility classes for 26 hue steps

## Testing
- `pnpm run build` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_683e6a18e8ac832e8a7786c2ef032dc9