### PR TITLE
Refine ASCII layout and add text mask

### DIFF
--- a/src/components/AsciiLayer.tsx
+++ b/src/components/AsciiLayer.tsx
@@ -37,15 +37,15 @@ function startAscii(canvas: HTMLCanvasElement, video: HTMLVideoElement) {
   // tighten grid size by 50%
   const cellW = 12
   const cellH = 16
-  // shrink font size by 20% while keeping line height equal to the cell height
-  ctx.font = '400 32px/16px "Micro 5", sans-serif'
+  // base font for ASCII grid - one step down the type scale
+  ctx.font = '400 24px/16px "Micro 5", sans-serif'
   ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'
   let raf: number
 
   const draw = () => {
     // ensure base font for ASCII grid
-    ctx.font = '400 32px/16px "Micro 5", sans-serif'
+    ctx.font = '400 24px/16px "Micro 5", sans-serif'
     const cols = Math.floor(canvas.width / cellW)
     const rows = Math.floor(canvas.height / cellH)
     ctx.drawImage(video, 0, 0, cols, rows)
@@ -77,27 +77,9 @@ function startAscii(canvas: HTMLCanvasElement, video: HTMLVideoElement) {
       }
     }
 
-    // draw static overlay text at 8x scale
-    const lines = ['DANNY', 'DURAN']
-    const scale = 8
-    const overlayFont = `800 ${32 * scale}px/${16 * scale}px "Micro 5", sans-serif`
-    ctx.fillStyle = '#ffffff'
-    ctx.font = overlayFont
-    const textCols = Math.max(...lines.map(l => l.length)) * scale
-    const textRows = lines.length * scale
-    const startCol = Math.floor((cols - textCols) / 2)
-    const startRow = Math.floor((rows - textRows) / 2)
-    lines.forEach((line, rowIndex) => {
-      for (let iChar = 0; iChar < line.length; iChar++) {
-        const ch = line[iChar]
-        const x = (startCol + iChar * scale + scale / 2) * cellW
-        const y = (startRow + rowIndex * scale + scale / 2) * cellH
-        ctx.fillText(ch, x, y)
-      }
-    })
 
     // reset font for next frame
-    ctx.font = '400 32px/16px "Micro 5", sans-serif'
+    ctx.font = '400 24px/16px "Micro 5", sans-serif'
 
     raf = requestAnimationFrame(draw)
   }

--- a/src/components/HeroMontage.tsx
+++ b/src/components/HeroMontage.tsx
@@ -84,17 +84,56 @@ export function HeroMontage() {
 
   return (
     <section className="fixed inset-0 overflow-hidden">
-      <video
-        ref={videoRef}
-        src={data?.src}
-        autoPlay
-        muted
-        loop
-        playsInline
-        crossOrigin="anonymous"
-        className="absolute inset-0 h-full w-full object-cover opacity-0"
-      />
-      <AsciiLayer target={videoRef} ready={!!data} onError={setAsciiError} />
+      <svg className="absolute inset-0 w-full h-full pointer-events-none">
+        <defs>
+          <mask id="name-mask" x="0" y="0" width="100%" height="100%">
+            <rect width="100%" height="100%" fill="white" />
+            <text
+              x="33.333%"
+              y="40%"
+              text-anchor="start"
+              fill="black"
+              font-family="'Micro 5', sans-serif"
+              font-weight="800"
+              font-size="20vw"
+            >
+              DANNY
+            </text>
+            <text
+              x="33.333%"
+              y="80%"
+              text-anchor="start"
+              fill="black"
+              font-family="'Micro 5', sans-serif"
+              font-weight="800"
+              font-size="20vw"
+            >
+              DURAN
+            </text>
+          </mask>
+        </defs>
+      </svg>
+      <div
+        className="absolute inset-0"
+        style={{ mask: 'url(#name-mask)', WebkitMask: 'url(#name-mask)' }}
+      >
+        <video
+          ref={videoRef}
+          src={data?.src}
+          autoPlay
+          muted
+          loop
+          playsInline
+          crossOrigin="anonymous"
+          className="absolute inset-0 h-full w-full object-cover opacity-0"
+        />
+        <AsciiLayer target={videoRef} ready={!!data} onError={setAsciiError} />
+      </div>
+      <div className="absolute inset-0 pointer-events-none flex items-start pl-[33.333%]">
+        <h1 className="font-micro5 font-extrabold leading-none text-[20vw] text-white text-left">
+          DANNY<br />DURAN
+        </h1>
+      </div>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- reduce font size for ASCII grid
- drop canvas-based overlay text
- mask ASCII canvas using 'DANNY DURAN' text
- place typography at the 33.3% grid line

## Testing
- `pnpm run build` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683e7c2e65f4832ea33dcf0e4ccd8f26