### PR TITLE
Remove hero matte

### DIFF
--- a/src/components/HeroMontage.tsx
+++ b/src/components/HeroMontage.tsx
@@ -84,55 +84,21 @@ export function HeroMontage() {
 
   return (
     <section className="fixed inset-0 overflow-hidden">
-      <svg className="absolute inset-0 w-full h-full pointer-events-none">
-        <defs>
-          <mask id="name-mask" x="0" y="0" width="100%" height="100%">
-            <rect width="100%" height="100%" fill="white" />
-            <text
-              x="33.333%"
-              y="40%"
-              text-anchor="start"
-              fill="black"
-              font-family="'Micro 5', sans-serif"
-              font-weight="800"
-              font-size="20vw"
-            >
-              DANNY
-            </text>
-            <text
-              x="33.333%"
-              y="80%"
-              text-anchor="start"
-              fill="black"
-              font-family="'Micro 5', sans-serif"
-              font-weight="800"
-              font-size="20vw"
-            >
-              DURAN
-            </text>
-          </mask>
-        </defs>
-      </svg>
-      <div
-        className="absolute inset-0"
-        style={{ mask: 'url(#name-mask)', WebkitMask: 'url(#name-mask)' }}
-      >
-        <video
-          ref={videoRef}
-          src={data?.src}
-          autoPlay
-          muted
-          loop
-          playsInline
-          crossOrigin="anonymous"
-          className="absolute inset-0 h-full w-full object-cover opacity-0"
-        />
-        <AsciiLayer target={videoRef} ready={!!data} onError={setAsciiError} />
-      </div>
-      <div className="absolute inset-0 pointer-events-none flex items-start pl-[33.333%]">
-        <h1 className="font-micro5 font-extrabold leading-none text-[20vw] text-white text-left">
-          DANNY<br />DURAN
-        </h1>
+      <video
+        ref={videoRef}
+        src={data?.src}
+        autoPlay
+        muted
+        loop
+        playsInline
+        crossOrigin="anonymous"
+        className="absolute inset-0 h-full w-full object-cover opacity-0"
+      />
+      <AsciiLayer target={videoRef} ready={!!data} onError={setAsciiError} />
+      <div className="absolute bottom-4 left-4 pointer-events-none">
+        <span className="font-micro5 font-extrabold border-2 border-white p-0.5 text-white">
+          DANNY DURAN
+        </span>
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- strip out SVG mask and giant text overlay
- keep small name in bottom corner with tighter padding

## Testing
- `pnpm build` *(fails: EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683e7f945090832eb777214f5afe9e55