### PR TITLE
Adjust ASCII grid and remove overlay

### DIFF
--- a/src/components/AsciiLayer.tsx
+++ b/src/components/AsciiLayer.tsx
@@ -34,9 +34,9 @@ function startAscii(canvas: HTMLCanvasElement, video: HTMLVideoElement) {
   const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
   const charCount = alphabet.length
   const shadows = ' .:-=+*#%@'
-  // tighten grid size by 50%
-  const cellW = 12
-  const cellH = 16
+  // decrease grid spacing by 50%
+  const cellW = 6
+  const cellH = 8
   // base font for ASCII grid - one step down the type scale
   ctx.font = '400 24px/16px "Micro 5", sans-serif'
   ctx.textAlign = 'center'

--- a/src/components/HeroMontage.tsx
+++ b/src/components/HeroMontage.tsx
@@ -95,11 +95,6 @@ export function HeroMontage() {
         className="absolute inset-0 h-full w-full object-cover opacity-0"
       />
       <AsciiLayer target={videoRef} ready={!!data} onError={setAsciiError} />
-      <div className="absolute bottom-4 left-4 pointer-events-none">
-        <span className="font-micro5 font-extrabold border-2 border-white p-0.5 text-white">
-          DANNY DURAN
-        </span>
-      </div>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- refine ASCII grid spacing
- remove bottom-left nameplate overlay

## Testing
- `pnpm run build` *(fails: request to pnpm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_683f69530844832eb59e4ff649337286